### PR TITLE
Renaming import "github.com/vmihailenco/msgpack" to "gopkg.in/vmihail…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ go test
 ## Credit
 
 * [@tarruda](https://github.com/tarruda) for leading the way with his [python-client](https://github.com/neovim/python-client)
-* [@vmihailenco](https://github.com/vmihailenco) for [msgpack](https://github.com/vmihailenco/msgpack)
+* [@vmihailenco](https://github.com/vmihailenco) for [msgpack](https://gopkg.in/vmihailenco/msgpack.v2)
 
 ## Todo list
 

--- a/apidef/encode_decode.go
+++ b/apidef/encode_decode.go
@@ -2,7 +2,7 @@ package apidef
 
 import (
 	"github.com/juju/errors"
-	"github.com/vmihailenco/msgpack"
+	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 // An API represents the API as advertised by Neovim

--- a/cmd/gen_neovim_api/gen_neovim_api.go
+++ b/cmd/gen_neovim_api/gen_neovim_api.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/myitcv/neovim/apidef"
-	"github.com/vmihailenco/msgpack"
+	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 var generatedFunctions map[string]bool

--- a/example/gen_example.go
+++ b/example/gen_example.go
@@ -3,7 +3,7 @@ package example
 import (
 	"github.com/juju/errors"
 	"github.com/myitcv/neovim"
-	"github.com/vmihailenco/msgpack"
+	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 func (e *Example) newBufCreateChanHandler() (chan *BufCreate, neovim.NewAsyncDecoder) {

--- a/init_method.go
+++ b/init_method.go
@@ -2,7 +2,7 @@ package neovim
 
 import (
 	"github.com/juju/errors"
-	"github.com/vmihailenco/msgpack"
+	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 type InitMethodWrapper struct {

--- a/neovim.go
+++ b/neovim.go
@@ -71,7 +71,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/myitcv/neovim/apidef"
-	"github.com/vmihailenco/msgpack"
+	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 // NewUnixClient is a convenience method for creating a new *Client. Method signature matches

--- a/neovim_test.go
+++ b/neovim_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/myitcv/neovim"
-	"github.com/vmihailenco/msgpack"
+	"gopkg.in/vmihailenco/msgpack.v2"
 
 	. "gopkg.in/check.v1"
 )

--- a/types.go
+++ b/types.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/vmihailenco/msgpack"
+	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 //go:generate gotemplate "github.com/myitcv/neovim/template/syncmap" "respSyncMap(uint32, *responseHolder)"


### PR DESCRIPTION
Attempting to use this library results in the following error:

```
../../apidef/encode_decode.go:5:2: code in directory /mnt/storage/projects/go/src/github.com/vmihailenco/msgpack expects import "gopkg.in/vmihailenco/msgpack.v2"
```

It appears the msgpack library has changed its URL so neovim had to be updated to reflect this change...