### PR TITLE
Use msgp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+sudo: false
 
 # Until https://github.com/neovim/neovim/pull/1335 is merged
 before_install:
@@ -9,8 +10,8 @@ install:
   go get -d -t -v ./... && go build -v ./...
 
 go:
-  - 1.3
-  - tip
+  - 1.4
+  - 1.5
 
 env:
   - GOMAXPROCS=4

--- a/README.md
+++ b/README.md
@@ -8,13 +8,12 @@ Go package for writing [Neovim](http://neovim.org/) plugins
 go get github.com/myitcv/neovim
 ```
 
-This package is very much in alpha as [the Neovim API itsef](https://github.com/neovim/neovim/issues/973)
-is still in flux. Therefore, expect changes to this API.
+This package is very much in alpha. Therefore, expect changes to this API. Stuff will break.
 
 ## Overview and Writing plugins
 
-See [the wiki](https://github.com/myitcv/neovim/wiki/Overview-of-writing-and-using-Go-packages-with-Neovim) for more
-details.
+See the [`Example`](https://github.com/myitcv/neovim/tree/master/example) plugin for a brief `README` on how to
+implement your own Go plugin.
 
 ## Supported platforms
 
@@ -25,13 +24,14 @@ Support welcomed on other platforms
 ## Tests
 
 ```bash
-go test
+go test ./...
 ```
 
 ## Credit
 
+* The entire [Neovim](https://github.com/neovim/neovim) team for their work
 * [@tarruda](https://github.com/tarruda) for leading the way with his [python-client](https://github.com/neovim/python-client)
-* [@vmihailenco](https://github.com/vmihailenco) for [msgpack](https://github.com/vmihailenco/msgpack)
+* [@philhofer](https://github.com/philhofer) et al for the excellent [`msgp`](https://github.com/tinylib/msgp)
 
 ## Todo list
 

--- a/cmd/neovim-go-plugin-manager/neovim-go-plugin-manager.go
+++ b/cmd/neovim-go-plugin-manager/neovim-go-plugin-manager.go
@@ -135,7 +135,7 @@ func install(pkg string) string {
 	c = newCommand(envo, "go", "test", pkg)
 	output, err = c.CombinedOutput()
 	if err != nil {
-		log.Fatalf("Could not go test plugin: %v\n", err)
+		log.Fatalf("Could not go test plugin: %v\n", string(output))
 	}
 
 	// Now we need to get the exported types that implement the neovim.Plugin

--- a/encode_decode.go
+++ b/encode_decode.go
@@ -7,7 +7,7 @@ package neovim
 import "github.com/juju/errors"
 
 func (c *Client) decodeString() (retVal string, retErr error) {
-	b, err := c.dec.DecodeBytes()
+	b, err := c.dec.ReadBytes(nil)
 	if err != nil {
 		return retVal, errors.Annotatef(err, "Could not decode string raw bytes")
 	}
@@ -15,7 +15,7 @@ func (c *Client) decodeString() (retVal string, retErr error) {
 }
 
 func (c *Client) encodeString(s string) error {
-	err := c.enc.EncodeBytes([]byte(s))
+	err := c.enc.WriteBytes([]byte(s))
 	if err != nil {
 		return errors.Annotatef(err, "Could not encode string raw bytes")
 	}

--- a/example/README.md
+++ b/example/README.md
@@ -1,3 +1,80 @@
 ## `github.com/myitcv/neovim/example`
 
 A bare-bones example of a Neovim plugin written in Go
+
+Writing a plugin currently involves a number of steps which will be automated with time:
+
+1. Defining the equivalent of `Example` (`example.go`), a type that implements `neovim.Plugin`
+2. Defining sync and async plugin methods, such as `GetTwoNumbers` and `DoSomethingAsync`
+3. Generating (by hand for now) wrappers around these types (`gen_example.go`)
+4. Generating (using `msgp`) MSGPACK wrappers around the wrappers (!) (`gen_example_gen.go`)
+5. Testing that this all works (`example_test.go`) with Neovim: `go test`
+6. Generating (by hand for now) the necessary bootstrap/wrappers to register these functions with Neovim
+
+Clearly all the steps after step 2 should be automated in some fashion. See the
+[TODO](https://github.com/myitcv/neovim/wiki/TODO) for a more up-to-date list of what remains to be done.
+
+## Installing and using the `Example` plugin
+
+0. `mkdir -p $HOME/.nvim/plugins/go/`
+1. `cd cmd/neovim-go-plugin-manager`
+2. `go build`
+3. `./neovim-go-plugin-manager github.com/myitcv/neovim/example`
+
+Append the following to your `$HOME/.nvimrc` file:
+
+```vimscript
+function! s:RequireGoHost(host)
+  try
+    let channel_id = rpcstart($HOME.'/.nvim/plugins/go/plugin_host')
+    call rpcrequest(channel_id, 'plugin_load', 'go')
+    return channel_id
+  catch
+    echomsg v:exception
+  endtry
+  throw 'Failed to load Go host'.
+endfunction
+
+if has('nvim')
+  call remote#host#Register('go', '*', function('s:RequireGoHost'))
+  try
+    call remote#define#FunctionOnHost('go', 'GetTwoNumbers', 1, 'GetTwoNumbers', {})
+    call remote#define#FunctionOnHost('go', 'DoSomethingAsync', 0, 'DoSomethingAsync', {})
+  catch
+    echomsg v:exception
+  endtry
+endif
+```
+
+Now launch `nvim` and try:
+
+```
+:echo GetTwoNumbers(5)
+```
+
+The output should read:
+
+```
+[47, '42']
+```
+
+If you tail the equivalent of `/tmp/neovim_go_plugin_host` then you should also see output:
+
+```
+$ tail -f /tmp/neovim_go_plugin_host
+2015/08/25 11:45:09 /tmp/neovim-go-plugin-manager_1440497199966172499/plugin_host.go:66: Successfully connected to Neovim
+2015/08/25 11:45:09 /tmp/neovim-go-plugin-manager_1440497199966172499/plugin_host.go:81: Connecting *example.Example
+2015/08/25 11:45:09 /tmp/neovim-go-plugin-manager_1440497199966172499/plugin_host.go:86: Successfully called Init on *example.Example
+```
+
+You can also call the async method `DoSomethingAsync` from `nvim`:
+
+```
+:call DoSomethingAsync("test_string")
+```
+
+This results in the following line being appended to the host log file:
+
+```
+2015/08/25 11:45:56 /tmp/neovim-go-plugin-manager_1440497199966172499/plugin_host.go:152: *example.ExampleGot an event: test_string
+```

--- a/example/example.go
+++ b/example/example.go
@@ -1,31 +1,22 @@
 package example
 
-import
-
-// import the neovim package
-"github.com/myitcv/neovim"
+import "github.com/myitcv/neovim"
 
 type Example struct {
-	client *neovim.Client
-	log    neovim.Logger
+	client                *neovim.Client
+	log                   neovim.Logger
+	doSomethingAsyncChans []chan string
 }
 
 func (n *Example) Init(c *neovim.Client, l neovim.Logger) error {
 	n.client = c
 	n.log = l
 
-	err := n.client.RegisterSyncRequestHandler(":function:GetANumber", n.newGetANumberResponder)
-	if err != nil {
-		n.log.Fatalf("Could not register sync request handler: %v\n", err)
-	}
+	n.client.RegisterSyncRequestHandler("GetTwoNumbers", n.newGetTwoNumbersResponder)
+	n.client.RegisterAsyncRequestHandler("DoSomethingAsync", n.newDoSomethingAsyncResponder)
 
-	ch, d := n.newBufCreateChanHandler()
-	err = n.client.RegisterAsyncRequestHandler(":autocmd:BufCreate:*", d)
-	if err != nil {
-		n.log.Fatalf("Could not register async request handler: %v\n", err)
-	}
-
-	n.log.Println("*****************")
+	ch := make(chan string)
+	n.AddDoSomethingAsyncChan(ch)
 	go n.subLoop(ch)
 
 	return nil
@@ -35,21 +26,36 @@ func (n *Example) Shutdown() error {
 	return nil
 }
 
-type BufCreate struct {
-	BufNumber int
+type theThing struct {
+	i int
 }
 
-func (n *Example) GetANumber() (int, error, error) {
-	return 42, nil, nil
+// a synchronous method that returns two numbers
+func (n *Example) GetTwoNumbers(i int) (int, string, error, error) {
+	return i + 42, "42", nil, nil
 }
 
-func (n *Example) subLoop(ch chan *BufCreate) {
+func (n *Example) AddDoSomethingAsyncChan(c chan string) {
+	// TODO clearly this is not thread safe
+	n.doSomethingAsyncChans = append(n.doSomethingAsyncChans, c)
+}
+
+// an async method defines no return values
+func (n *Example) DoSomethingAsync(s string) error {
+	// TODO clearly this is not thread safe
+	for _, c := range n.doSomethingAsyncChans {
+		c <- s
+	}
+	return nil
+}
+
+func (n *Example) subLoop(ch chan string) {
 	for {
 		select {
 		case <-n.client.KillChannel:
 			return
 		case v := <-ch:
-			n.log.Printf("Got a %v event\n", v)
+			n.log.Printf("Got an event: %v\n", v)
 		}
 	}
 }

--- a/example/gen_example_gen.go
+++ b/example/gen_example_gen.go
@@ -1,0 +1,415 @@
+package example
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"github.com/tinylib/msgp/msgp"
+)
+
+// DecodeMsg implements msgp.Decodable
+func (z *DoSomethingAsyncArgs) DecodeMsg(dc *msgp.Reader) (err error) {
+	var ssz uint32
+	ssz, err = dc.ReadArrayHeader()
+	if err != nil {
+		return
+	}
+	if ssz != 1 {
+		err = msgp.ArrayError{Wanted: 1, Got: ssz}
+		return
+	}
+	{
+		var ssz uint32
+		ssz, err = dc.ReadArrayHeader()
+		if err != nil {
+			return
+		}
+		if ssz != 1 {
+			err = msgp.ArrayError{Wanted: 1, Got: ssz}
+			return
+		}
+		{
+			z.FunctionArgs.Arg0, err = dc.ReadBytes(z.FunctionArgs.Arg0)
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *DoSomethingAsyncArgs) EncodeMsg(en *msgp.Writer) (err error) {
+	// array header, size 1
+	// array header, size 1
+	err = en.Append(0x91, 0x91)
+	if err != nil {
+		return err
+	}
+	err = en.WriteBytes(z.FunctionArgs.Arg0)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *DoSomethingAsyncArgs) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// array header, size 1
+	// array header, size 1
+	o = append(o, 0x91, 0x91)
+	o = msgp.AppendBytes(o, z.FunctionArgs.Arg0)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *DoSomethingAsyncArgs) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	{
+		var ssz uint32
+		ssz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			return
+		}
+		if ssz != 1 {
+			err = msgp.ArrayError{Wanted: 1, Got: ssz}
+			return
+		}
+	}
+	{
+		var ssz uint32
+		ssz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			return
+		}
+		if ssz != 1 {
+			err = msgp.ArrayError{Wanted: 1, Got: ssz}
+			return
+		}
+	}
+	z.FunctionArgs.Arg0, bts, err = msgp.ReadBytesBytes(bts, z.FunctionArgs.Arg0)
+	if err != nil {
+		return
+	}
+	o = bts
+	return
+}
+
+func (z *DoSomethingAsyncArgs) Msgsize() (s int) {
+	s = 1 + 1 + msgp.BytesPrefixSize + len(z.FunctionArgs.Arg0)
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *DoSomethingAsyncFunctionArgs) DecodeMsg(dc *msgp.Reader) (err error) {
+	var ssz uint32
+	ssz, err = dc.ReadArrayHeader()
+	if err != nil {
+		return
+	}
+	if ssz != 1 {
+		err = msgp.ArrayError{Wanted: 1, Got: ssz}
+		return
+	}
+	{
+		z.Arg0, err = dc.ReadBytes(z.Arg0)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *DoSomethingAsyncFunctionArgs) EncodeMsg(en *msgp.Writer) (err error) {
+	// array header, size 1
+	err = en.Append(0x91)
+	if err != nil {
+		return err
+	}
+	err = en.WriteBytes(z.Arg0)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *DoSomethingAsyncFunctionArgs) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// array header, size 1
+	o = append(o, 0x91)
+	o = msgp.AppendBytes(o, z.Arg0)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *DoSomethingAsyncFunctionArgs) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	{
+		var ssz uint32
+		ssz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			return
+		}
+		if ssz != 1 {
+			err = msgp.ArrayError{Wanted: 1, Got: ssz}
+			return
+		}
+	}
+	z.Arg0, bts, err = msgp.ReadBytesBytes(bts, z.Arg0)
+	if err != nil {
+		return
+	}
+	o = bts
+	return
+}
+
+func (z *DoSomethingAsyncFunctionArgs) Msgsize() (s int) {
+	s = 1 + msgp.BytesPrefixSize + len(z.Arg0)
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *GetTwoNumbersArgs) DecodeMsg(dc *msgp.Reader) (err error) {
+	var ssz uint32
+	ssz, err = dc.ReadArrayHeader()
+	if err != nil {
+		return
+	}
+	if ssz != 1 {
+		err = msgp.ArrayError{Wanted: 1, Got: ssz}
+		return
+	}
+	{
+		var ssz uint32
+		ssz, err = dc.ReadArrayHeader()
+		if err != nil {
+			return
+		}
+		if ssz != 1 {
+			err = msgp.ArrayError{Wanted: 1, Got: ssz}
+			return
+		}
+		{
+			z.FunctionArgs.Arg0, err = dc.ReadInt64()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *GetTwoNumbersArgs) EncodeMsg(en *msgp.Writer) (err error) {
+	// array header, size 1
+	// array header, size 1
+	err = en.Append(0x91, 0x91)
+	if err != nil {
+		return err
+	}
+	err = en.WriteInt64(z.FunctionArgs.Arg0)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *GetTwoNumbersArgs) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// array header, size 1
+	// array header, size 1
+	o = append(o, 0x91, 0x91)
+	o = msgp.AppendInt64(o, z.FunctionArgs.Arg0)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *GetTwoNumbersArgs) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	{
+		var ssz uint32
+		ssz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			return
+		}
+		if ssz != 1 {
+			err = msgp.ArrayError{Wanted: 1, Got: ssz}
+			return
+		}
+	}
+	{
+		var ssz uint32
+		ssz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			return
+		}
+		if ssz != 1 {
+			err = msgp.ArrayError{Wanted: 1, Got: ssz}
+			return
+		}
+	}
+	z.FunctionArgs.Arg0, bts, err = msgp.ReadInt64Bytes(bts)
+	if err != nil {
+		return
+	}
+	o = bts
+	return
+}
+
+func (z *GetTwoNumbersArgs) Msgsize() (s int) {
+	s = 1 + 1 + msgp.Int64Size
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *GetTwoNumbersFunctionArgs) DecodeMsg(dc *msgp.Reader) (err error) {
+	var ssz uint32
+	ssz, err = dc.ReadArrayHeader()
+	if err != nil {
+		return
+	}
+	if ssz != 1 {
+		err = msgp.ArrayError{Wanted: 1, Got: ssz}
+		return
+	}
+	{
+		z.Arg0, err = dc.ReadInt64()
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z GetTwoNumbersFunctionArgs) EncodeMsg(en *msgp.Writer) (err error) {
+	// array header, size 1
+	err = en.Append(0x91)
+	if err != nil {
+		return err
+	}
+	err = en.WriteInt64(z.Arg0)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z GetTwoNumbersFunctionArgs) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// array header, size 1
+	o = append(o, 0x91)
+	o = msgp.AppendInt64(o, z.Arg0)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *GetTwoNumbersFunctionArgs) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	{
+		var ssz uint32
+		ssz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			return
+		}
+		if ssz != 1 {
+			err = msgp.ArrayError{Wanted: 1, Got: ssz}
+			return
+		}
+	}
+	z.Arg0, bts, err = msgp.ReadInt64Bytes(bts)
+	if err != nil {
+		return
+	}
+	o = bts
+	return
+}
+
+func (z GetTwoNumbersFunctionArgs) Msgsize() (s int) {
+	s = 1 + msgp.Int64Size
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *GetTwoNumbersResults) DecodeMsg(dc *msgp.Reader) (err error) {
+	var ssz uint32
+	ssz, err = dc.ReadArrayHeader()
+	if err != nil {
+		return
+	}
+	if ssz != 2 {
+		err = msgp.ArrayError{Wanted: 2, Got: ssz}
+		return
+	}
+	{
+		z.Ret0, err = dc.ReadInt64()
+		if err != nil {
+			return
+		}
+		z.Ret1, err = dc.ReadBytes(z.Ret1)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *GetTwoNumbersResults) EncodeMsg(en *msgp.Writer) (err error) {
+	// array header, size 2
+	err = en.Append(0x92)
+	if err != nil {
+		return err
+	}
+	err = en.WriteInt64(z.Ret0)
+	if err != nil {
+		return
+	}
+	err = en.WriteBytes(z.Ret1)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *GetTwoNumbersResults) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// array header, size 2
+	o = append(o, 0x92)
+	o = msgp.AppendInt64(o, z.Ret0)
+	o = msgp.AppendBytes(o, z.Ret1)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *GetTwoNumbersResults) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	{
+		var ssz uint32
+		ssz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			return
+		}
+		if ssz != 2 {
+			err = msgp.ArrayError{Wanted: 2, Got: ssz}
+			return
+		}
+	}
+	z.Ret0, bts, err = msgp.ReadInt64Bytes(bts)
+	if err != nil {
+		return
+	}
+	z.Ret1, bts, err = msgp.ReadBytesBytes(bts, z.Ret1)
+	if err != nil {
+		return
+	}
+	o = bts
+	return
+}
+
+func (z *GetTwoNumbersResults) Msgsize() (s int) {
+	s = 1 + msgp.Int64Size + msgp.BytesPrefixSize + len(z.Ret1)
+	return
+}

--- a/example/gen_example_gen_test.go
+++ b/example/gen_example_gen_test.go
@@ -1,0 +1,577 @@
+package example
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestMarshalUnmarshalDoSomethingAsyncArgs(t *testing.T) {
+	v := DoSomethingAsyncArgs{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgDoSomethingAsyncArgs(b *testing.B) {
+	v := DoSomethingAsyncArgs{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgDoSomethingAsyncArgs(b *testing.B) {
+	v := DoSomethingAsyncArgs{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalDoSomethingAsyncArgs(b *testing.B) {
+	v := DoSomethingAsyncArgs{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeDoSomethingAsyncArgs(t *testing.T) {
+	v := DoSomethingAsyncArgs{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := DoSomethingAsyncArgs{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeDoSomethingAsyncArgs(b *testing.B) {
+	v := DoSomethingAsyncArgs{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeDoSomethingAsyncArgs(b *testing.B) {
+	v := DoSomethingAsyncArgs{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalDoSomethingAsyncFunctionArgs(t *testing.T) {
+	v := DoSomethingAsyncFunctionArgs{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgDoSomethingAsyncFunctionArgs(b *testing.B) {
+	v := DoSomethingAsyncFunctionArgs{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgDoSomethingAsyncFunctionArgs(b *testing.B) {
+	v := DoSomethingAsyncFunctionArgs{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalDoSomethingAsyncFunctionArgs(b *testing.B) {
+	v := DoSomethingAsyncFunctionArgs{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeDoSomethingAsyncFunctionArgs(t *testing.T) {
+	v := DoSomethingAsyncFunctionArgs{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := DoSomethingAsyncFunctionArgs{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeDoSomethingAsyncFunctionArgs(b *testing.B) {
+	v := DoSomethingAsyncFunctionArgs{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeDoSomethingAsyncFunctionArgs(b *testing.B) {
+	v := DoSomethingAsyncFunctionArgs{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalGetTwoNumbersArgs(t *testing.T) {
+	v := GetTwoNumbersArgs{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgGetTwoNumbersArgs(b *testing.B) {
+	v := GetTwoNumbersArgs{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgGetTwoNumbersArgs(b *testing.B) {
+	v := GetTwoNumbersArgs{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalGetTwoNumbersArgs(b *testing.B) {
+	v := GetTwoNumbersArgs{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeGetTwoNumbersArgs(t *testing.T) {
+	v := GetTwoNumbersArgs{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := GetTwoNumbersArgs{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeGetTwoNumbersArgs(b *testing.B) {
+	v := GetTwoNumbersArgs{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeGetTwoNumbersArgs(b *testing.B) {
+	v := GetTwoNumbersArgs{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalGetTwoNumbersFunctionArgs(t *testing.T) {
+	v := GetTwoNumbersFunctionArgs{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgGetTwoNumbersFunctionArgs(b *testing.B) {
+	v := GetTwoNumbersFunctionArgs{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgGetTwoNumbersFunctionArgs(b *testing.B) {
+	v := GetTwoNumbersFunctionArgs{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalGetTwoNumbersFunctionArgs(b *testing.B) {
+	v := GetTwoNumbersFunctionArgs{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeGetTwoNumbersFunctionArgs(t *testing.T) {
+	v := GetTwoNumbersFunctionArgs{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := GetTwoNumbersFunctionArgs{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeGetTwoNumbersFunctionArgs(b *testing.B) {
+	v := GetTwoNumbersFunctionArgs{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeGetTwoNumbersFunctionArgs(b *testing.B) {
+	v := GetTwoNumbersFunctionArgs{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalGetTwoNumbersResults(t *testing.T) {
+	v := GetTwoNumbersResults{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgGetTwoNumbersResults(b *testing.B) {
+	v := GetTwoNumbersResults{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgGetTwoNumbersResults(b *testing.B) {
+	v := GetTwoNumbersResults{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalGetTwoNumbersResults(b *testing.B) {
+	v := GetTwoNumbersResults{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeGetTwoNumbersResults(t *testing.T) {
+	v := GetTwoNumbersResults{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := GetTwoNumbersResults{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeGetTwoNumbersResults(b *testing.B) {
+	v := GetTwoNumbersResults{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeGetTwoNumbersResults(b *testing.B) {
+	v := GetTwoNumbersResults{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -14,62 +14,6 @@ import (
 	"github.com/myitcv/neovim"
 )
 
-// func ExampleSubscription() {
-// 	cmd := exec.Command(os.Getenv("NEOVIM_BIN"), "-u", "/dev/null")
-// 	cmd.Dir = "/tmp"
-
-// 	client, err := neovim.NewCmdClient(neovim.NullInitMethod, cmd, nil)
-// 	if err != nil {
-// 		log.Fatalf("Could not create new client: %v", errors.Details(err))
-// 	}
-// 	client.PanicOnError = true
-
-// 	topic := "topic1"
-// 	sub, err := client.Subscribe(topic)
-// 	if err != nil {
-// 		log.Fatalf("Could not subscribe to topic %v: %v", topic, errors.Details(err))
-// 	}
-
-// 	unsubbed := make(chan struct{})
-// 	done := make(chan struct{})
-// 	received := make(chan struct{})
-
-// 	go func() {
-// 	ForLoop:
-// 		for {
-// 			select {
-// 			case e := <-sub.Events:
-// 				if e == nil {
-// 					break ForLoop
-// 				}
-// 				fmt.Printf("We got %v\n", e.Value)
-// 				received <- struct{}{}
-// 			}
-// 		}
-// 		done <- struct{}{}
-// 	}()
-
-// 	command := fmt.Sprintf(`call rpcnotify(0, "%v", 1)`, topic)
-// 	_ = client.Command(command)
-
-// 	<-received
-
-// 	go func() {
-
-// 		_ = client.Unsubscribe(sub)
-// 		unsubbed <- struct{}{}
-// 	}()
-
-// 	<-done
-
-// 	<-unsubbed
-
-// 	_ = client.Close()
-
-// 	// Output:
-// 	// We got [1]
-// }
-
 func ExampleClient_GetCurrentBuffer() {
 	cmd := exec.Command(os.Getenv("NEOVIM_BIN"), "-u", "/dev/null")
 	cmd.Dir = "/tmp"

--- a/gen_client_api.go
+++ b/gen_client_api.go
@@ -7,9 +7,9 @@ import "github.com/juju/errors"
 // constants representing method ids
 
 const (
-	typeBuffer  uint8 = 0
-	typeWindow  uint8 = 1
-	typeTabpage uint8 = 2
+	typeBuffer  int8 = 0
+	typeWindow  int8 = 1
+	typeTabpage int8 = 2
 )
 
 const (
@@ -53,6 +53,7 @@ const (
 	clientGetWindows        = "vim_get_windows"
 	clientInput             = "vim_input"
 	clientListRuntimePaths  = "vim_list_runtime_paths"
+	clientNameToColor       = "vim_name_to_color"
 	clientOutWrite          = "vim_out_write"
 	clientReplaceTermcodes  = "vim_replace_termcodes"
 	clientReportError       = "vim_report_error"
@@ -87,7 +88,7 @@ const (
 func (b *Buffer) DelLine(index int) error {
 
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(2)
+		_err = b.client.enc.WriteArrayHeader(2)
 		if _err != nil {
 			return
 		}
@@ -97,7 +98,7 @@ func (b *Buffer) DelLine(index int) error {
 			return
 		}
 
-		_err = b.client.enc.EncodeInt(index)
+		_err = b.client.enc.WriteInt(index)
 
 		if _err != nil {
 			return
@@ -107,7 +108,7 @@ func (b *Buffer) DelLine(index int) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = b.client.dec.DecodeBytes()
+		_err = b.client.dec.ReadNil()
 
 		return
 	}
@@ -131,7 +132,7 @@ func (b *Buffer) DelLine(index int) error {
 func (b *Buffer) GetLine(index int) (string, error) {
 	var retVal string
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(2)
+		_err = b.client.enc.WriteArrayHeader(2)
 		if _err != nil {
 			return
 		}
@@ -141,7 +142,7 @@ func (b *Buffer) GetLine(index int) (string, error) {
 			return
 		}
 
-		_err = b.client.enc.EncodeInt(index)
+		_err = b.client.enc.WriteInt(index)
 
 		if _err != nil {
 			return
@@ -176,7 +177,7 @@ func (b *Buffer) GetLine(index int) (string, error) {
 func (b *Buffer) GetLineSlice(start int, end int, includeStart bool, includeEnd bool) ([]string, error) {
 	var retVal []string
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(5)
+		_err = b.client.enc.WriteArrayHeader(5)
 		if _err != nil {
 			return
 		}
@@ -186,25 +187,25 @@ func (b *Buffer) GetLineSlice(start int, end int, includeStart bool, includeEnd 
 			return
 		}
 
-		_err = b.client.enc.EncodeInt(start)
+		_err = b.client.enc.WriteInt(start)
 
 		if _err != nil {
 			return
 		}
 
-		_err = b.client.enc.EncodeInt(end)
+		_err = b.client.enc.WriteInt(end)
 
 		if _err != nil {
 			return
 		}
 
-		_err = b.client.enc.EncodeBool(includeStart)
+		_err = b.client.enc.WriteBool(includeStart)
 
 		if _err != nil {
 			return
 		}
 
-		_err = b.client.enc.EncodeBool(includeEnd)
+		_err = b.client.enc.WriteBool(includeEnd)
 
 		if _err != nil {
 			return
@@ -239,7 +240,7 @@ func (b *Buffer) GetLineSlice(start int, end int, includeStart bool, includeEnd 
 func (b *Buffer) GetMark(name string) ([]int, error) {
 	var retVal []int
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(2)
+		_err = b.client.enc.WriteArrayHeader(2)
 		if _err != nil {
 			return
 		}
@@ -284,7 +285,7 @@ func (b *Buffer) GetMark(name string) ([]int, error) {
 func (b *Buffer) GetName() (string, error) {
 	var retVal string
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(1)
+		_err = b.client.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -323,7 +324,7 @@ func (b *Buffer) GetName() (string, error) {
 func (b *Buffer) GetNumber() (int, error) {
 	var retVal int
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(1)
+		_err = b.client.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -337,7 +338,7 @@ func (b *Buffer) GetNumber() (int, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = b.client.dec.DecodeInt()
+		_i, _err = b.client.dec.ReadInt()
 
 		return
 	}
@@ -362,7 +363,7 @@ func (b *Buffer) GetNumber() (int, error) {
 func (b *Buffer) GetOption(name string) (interface{}, error) {
 	var retVal interface{}
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(2)
+		_err = b.client.enc.WriteArrayHeader(2)
 		if _err != nil {
 			return
 		}
@@ -382,7 +383,7 @@ func (b *Buffer) GetOption(name string) (interface{}, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = b.client.dec.DecodeInterface()
+		_i, _err = b.client.dec.ReadIntf()
 
 		return
 	}
@@ -407,7 +408,7 @@ func (b *Buffer) GetOption(name string) (interface{}, error) {
 func (b *Buffer) GetVar(name string) (interface{}, error) {
 	var retVal interface{}
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(2)
+		_err = b.client.enc.WriteArrayHeader(2)
 		if _err != nil {
 			return
 		}
@@ -427,7 +428,7 @@ func (b *Buffer) GetVar(name string) (interface{}, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = b.client.dec.DecodeInterface()
+		_i, _err = b.client.dec.ReadIntf()
 
 		return
 	}
@@ -452,7 +453,7 @@ func (b *Buffer) GetVar(name string) (interface{}, error) {
 func (b *Buffer) Insert(lnum int, lines []string) error {
 
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(3)
+		_err = b.client.enc.WriteArrayHeader(3)
 		if _err != nil {
 			return
 		}
@@ -462,7 +463,7 @@ func (b *Buffer) Insert(lnum int, lines []string) error {
 			return
 		}
 
-		_err = b.client.enc.EncodeInt(lnum)
+		_err = b.client.enc.WriteInt(lnum)
 
 		if _err != nil {
 			return
@@ -478,7 +479,7 @@ func (b *Buffer) Insert(lnum int, lines []string) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = b.client.dec.DecodeBytes()
+		_err = b.client.dec.ReadNil()
 
 		return
 	}
@@ -502,7 +503,7 @@ func (b *Buffer) Insert(lnum int, lines []string) error {
 func (b *Buffer) IsValid() (bool, error) {
 	var retVal bool
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(1)
+		_err = b.client.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -516,7 +517,7 @@ func (b *Buffer) IsValid() (bool, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = b.client.dec.DecodeBool()
+		_i, _err = b.client.dec.ReadBool()
 
 		return
 	}
@@ -541,7 +542,7 @@ func (b *Buffer) IsValid() (bool, error) {
 func (b *Buffer) LineCount() (int, error) {
 	var retVal int
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(1)
+		_err = b.client.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -555,7 +556,7 @@ func (b *Buffer) LineCount() (int, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = b.client.dec.DecodeInt()
+		_i, _err = b.client.dec.ReadInt()
 
 		return
 	}
@@ -580,7 +581,7 @@ func (b *Buffer) LineCount() (int, error) {
 func (b *Buffer) SetLine(index int, line string) error {
 
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(3)
+		_err = b.client.enc.WriteArrayHeader(3)
 		if _err != nil {
 			return
 		}
@@ -590,7 +591,7 @@ func (b *Buffer) SetLine(index int, line string) error {
 			return
 		}
 
-		_err = b.client.enc.EncodeInt(index)
+		_err = b.client.enc.WriteInt(index)
 
 		if _err != nil {
 			return
@@ -606,7 +607,7 @@ func (b *Buffer) SetLine(index int, line string) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = b.client.dec.DecodeBytes()
+		_err = b.client.dec.ReadNil()
 
 		return
 	}
@@ -630,7 +631,7 @@ func (b *Buffer) SetLine(index int, line string) error {
 func (b *Buffer) SetLineSlice(start int, end int, includeStart bool, includeEnd bool, replacement []string) error {
 
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(6)
+		_err = b.client.enc.WriteArrayHeader(6)
 		if _err != nil {
 			return
 		}
@@ -640,25 +641,25 @@ func (b *Buffer) SetLineSlice(start int, end int, includeStart bool, includeEnd 
 			return
 		}
 
-		_err = b.client.enc.EncodeInt(start)
+		_err = b.client.enc.WriteInt(start)
 
 		if _err != nil {
 			return
 		}
 
-		_err = b.client.enc.EncodeInt(end)
+		_err = b.client.enc.WriteInt(end)
 
 		if _err != nil {
 			return
 		}
 
-		_err = b.client.enc.EncodeBool(includeStart)
+		_err = b.client.enc.WriteBool(includeStart)
 
 		if _err != nil {
 			return
 		}
 
-		_err = b.client.enc.EncodeBool(includeEnd)
+		_err = b.client.enc.WriteBool(includeEnd)
 
 		if _err != nil {
 			return
@@ -674,7 +675,7 @@ func (b *Buffer) SetLineSlice(start int, end int, includeStart bool, includeEnd 
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = b.client.dec.DecodeBytes()
+		_err = b.client.dec.ReadNil()
 
 		return
 	}
@@ -698,7 +699,7 @@ func (b *Buffer) SetLineSlice(start int, end int, includeStart bool, includeEnd 
 func (b *Buffer) SetName(name string) error {
 
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(2)
+		_err = b.client.enc.WriteArrayHeader(2)
 		if _err != nil {
 			return
 		}
@@ -718,7 +719,7 @@ func (b *Buffer) SetName(name string) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = b.client.dec.DecodeBytes()
+		_err = b.client.dec.ReadNil()
 
 		return
 	}
@@ -742,7 +743,7 @@ func (b *Buffer) SetName(name string) error {
 func (b *Buffer) SetOption(name string, value interface{}) error {
 
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(3)
+		_err = b.client.enc.WriteArrayHeader(3)
 		if _err != nil {
 			return
 		}
@@ -758,7 +759,7 @@ func (b *Buffer) SetOption(name string, value interface{}) error {
 			return
 		}
 
-		_err = b.client.enc.Encode(value)
+		_err = b.client.enc.WriteIntf(value)
 
 		if _err != nil {
 			return
@@ -768,7 +769,7 @@ func (b *Buffer) SetOption(name string, value interface{}) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = b.client.dec.DecodeBytes()
+		_err = b.client.dec.ReadNil()
 
 		return
 	}
@@ -792,7 +793,7 @@ func (b *Buffer) SetOption(name string, value interface{}) error {
 func (b *Buffer) SetVar(name string, value interface{}) (interface{}, error) {
 	var retVal interface{}
 	enc := func() (_err error) {
-		_err = b.client.enc.EncodeSliceLen(3)
+		_err = b.client.enc.WriteArrayHeader(3)
 		if _err != nil {
 			return
 		}
@@ -808,7 +809,7 @@ func (b *Buffer) SetVar(name string, value interface{}) (interface{}, error) {
 			return
 		}
 
-		_err = b.client.enc.Encode(value)
+		_err = b.client.enc.WriteIntf(value)
 
 		if _err != nil {
 			return
@@ -818,7 +819,7 @@ func (b *Buffer) SetVar(name string, value interface{}) (interface{}, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = b.client.dec.DecodeInterface()
+		_i, _err = b.client.dec.ReadIntf()
 
 		return
 	}
@@ -843,7 +844,7 @@ func (b *Buffer) SetVar(name string, value interface{}) (interface{}, error) {
 func (t *Tabpage) GetVar(name string) (interface{}, error) {
 	var retVal interface{}
 	enc := func() (_err error) {
-		_err = t.client.enc.EncodeSliceLen(2)
+		_err = t.client.enc.WriteArrayHeader(2)
 		if _err != nil {
 			return
 		}
@@ -863,7 +864,7 @@ func (t *Tabpage) GetVar(name string) (interface{}, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = t.client.dec.DecodeInterface()
+		_i, _err = t.client.dec.ReadIntf()
 
 		return
 	}
@@ -888,7 +889,7 @@ func (t *Tabpage) GetVar(name string) (interface{}, error) {
 func (t *Tabpage) GetWindow() (Window, error) {
 	var retVal Window
 	enc := func() (_err error) {
-		_err = t.client.enc.EncodeSliceLen(1)
+		_err = t.client.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -927,7 +928,7 @@ func (t *Tabpage) GetWindow() (Window, error) {
 func (t *Tabpage) GetWindows() ([]Window, error) {
 	var retVal []Window
 	enc := func() (_err error) {
-		_err = t.client.enc.EncodeSliceLen(1)
+		_err = t.client.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -966,7 +967,7 @@ func (t *Tabpage) GetWindows() ([]Window, error) {
 func (t *Tabpage) IsValid() (bool, error) {
 	var retVal bool
 	enc := func() (_err error) {
-		_err = t.client.enc.EncodeSliceLen(1)
+		_err = t.client.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -980,7 +981,7 @@ func (t *Tabpage) IsValid() (bool, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = t.client.dec.DecodeBool()
+		_i, _err = t.client.dec.ReadBool()
 
 		return
 	}
@@ -1005,7 +1006,7 @@ func (t *Tabpage) IsValid() (bool, error) {
 func (t *Tabpage) SetVar(name string, value interface{}) (interface{}, error) {
 	var retVal interface{}
 	enc := func() (_err error) {
-		_err = t.client.enc.EncodeSliceLen(3)
+		_err = t.client.enc.WriteArrayHeader(3)
 		if _err != nil {
 			return
 		}
@@ -1021,7 +1022,7 @@ func (t *Tabpage) SetVar(name string, value interface{}) (interface{}, error) {
 			return
 		}
 
-		_err = t.client.enc.Encode(value)
+		_err = t.client.enc.WriteIntf(value)
 
 		if _err != nil {
 			return
@@ -1031,7 +1032,7 @@ func (t *Tabpage) SetVar(name string, value interface{}) (interface{}, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = t.client.dec.DecodeInterface()
+		_i, _err = t.client.dec.ReadIntf()
 
 		return
 	}
@@ -1056,7 +1057,7 @@ func (t *Tabpage) SetVar(name string, value interface{}) (interface{}, error) {
 func (c *Client) ChangeDirectory(dir string) error {
 
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -1071,7 +1072,7 @@ func (c *Client) ChangeDirectory(dir string) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = c.dec.DecodeBytes()
+		_err = c.dec.ReadNil()
 
 		return
 	}
@@ -1095,7 +1096,7 @@ func (c *Client) ChangeDirectory(dir string) error {
 func (c *Client) Command(str string) error {
 
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -1110,7 +1111,7 @@ func (c *Client) Command(str string) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = c.dec.DecodeBytes()
+		_err = c.dec.ReadNil()
 
 		return
 	}
@@ -1134,7 +1135,7 @@ func (c *Client) Command(str string) error {
 func (c *Client) CommandOutput(str string) (string, error) {
 	var retVal string
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -1174,7 +1175,7 @@ func (c *Client) CommandOutput(str string) (string, error) {
 func (c *Client) DelCurrentLine() error {
 
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(0)
+		_err = c.enc.WriteArrayHeader(0)
 		if _err != nil {
 			return
 		}
@@ -1183,7 +1184,7 @@ func (c *Client) DelCurrentLine() error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = c.dec.DecodeBytes()
+		_err = c.dec.ReadNil()
 
 		return
 	}
@@ -1207,7 +1208,7 @@ func (c *Client) DelCurrentLine() error {
 func (c *Client) ErrWrite(str string) error {
 
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -1222,7 +1223,7 @@ func (c *Client) ErrWrite(str string) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = c.dec.DecodeBytes()
+		_err = c.dec.ReadNil()
 
 		return
 	}
@@ -1246,7 +1247,7 @@ func (c *Client) ErrWrite(str string) error {
 func (c *Client) Eval(str string) (interface{}, error) {
 	var retVal interface{}
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -1261,7 +1262,7 @@ func (c *Client) Eval(str string) (interface{}, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = c.dec.DecodeInterface()
+		_i, _err = c.dec.ReadIntf()
 
 		return
 	}
@@ -1283,10 +1284,10 @@ func (c *Client) Eval(str string) (interface{}, error) {
 }
 
 // Feedkeys waiting for documentation from Neovim
-func (c *Client) Feedkeys(keys string, mode string) error {
+func (c *Client) Feedkeys(keys string, mode string, escapeCsi bool) error {
 
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(2)
+		_err = c.enc.WriteArrayHeader(3)
 		if _err != nil {
 			return
 		}
@@ -1303,11 +1304,17 @@ func (c *Client) Feedkeys(keys string, mode string) error {
 			return
 		}
 
+		_err = c.enc.WriteBool(escapeCsi)
+
+		if _err != nil {
+			return
+		}
+
 		return
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = c.dec.DecodeBytes()
+		_err = c.dec.ReadNil()
 
 		return
 	}
@@ -1331,7 +1338,7 @@ func (c *Client) Feedkeys(keys string, mode string) error {
 func (c *Client) GetBuffers() ([]Buffer, error) {
 	var retVal []Buffer
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(0)
+		_err = c.enc.WriteArrayHeader(0)
 		if _err != nil {
 			return
 		}
@@ -1365,7 +1372,7 @@ func (c *Client) GetBuffers() ([]Buffer, error) {
 func (c *Client) GetCurrentBuffer() (Buffer, error) {
 	var retVal Buffer
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(0)
+		_err = c.enc.WriteArrayHeader(0)
 		if _err != nil {
 			return
 		}
@@ -1399,7 +1406,7 @@ func (c *Client) GetCurrentBuffer() (Buffer, error) {
 func (c *Client) GetCurrentLine() (string, error) {
 	var retVal string
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(0)
+		_err = c.enc.WriteArrayHeader(0)
 		if _err != nil {
 			return
 		}
@@ -1433,7 +1440,7 @@ func (c *Client) GetCurrentLine() (string, error) {
 func (c *Client) GetCurrentTabpage() (Tabpage, error) {
 	var retVal Tabpage
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(0)
+		_err = c.enc.WriteArrayHeader(0)
 		if _err != nil {
 			return
 		}
@@ -1467,7 +1474,7 @@ func (c *Client) GetCurrentTabpage() (Tabpage, error) {
 func (c *Client) GetCurrentWindow() (Window, error) {
 	var retVal Window
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(0)
+		_err = c.enc.WriteArrayHeader(0)
 		if _err != nil {
 			return
 		}
@@ -1501,7 +1508,7 @@ func (c *Client) GetCurrentWindow() (Window, error) {
 func (c *Client) GetOption(name string) (interface{}, error) {
 	var retVal interface{}
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -1516,7 +1523,7 @@ func (c *Client) GetOption(name string) (interface{}, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = c.dec.DecodeInterface()
+		_i, _err = c.dec.ReadIntf()
 
 		return
 	}
@@ -1541,7 +1548,7 @@ func (c *Client) GetOption(name string) (interface{}, error) {
 func (c *Client) GetTabpages() ([]Tabpage, error) {
 	var retVal []Tabpage
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(0)
+		_err = c.enc.WriteArrayHeader(0)
 		if _err != nil {
 			return
 		}
@@ -1575,7 +1582,7 @@ func (c *Client) GetTabpages() ([]Tabpage, error) {
 func (c *Client) GetVar(name string) (interface{}, error) {
 	var retVal interface{}
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -1590,7 +1597,7 @@ func (c *Client) GetVar(name string) (interface{}, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = c.dec.DecodeInterface()
+		_i, _err = c.dec.ReadIntf()
 
 		return
 	}
@@ -1615,7 +1622,7 @@ func (c *Client) GetVar(name string) (interface{}, error) {
 func (c *Client) GetVvar(name string) (interface{}, error) {
 	var retVal interface{}
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -1630,7 +1637,7 @@ func (c *Client) GetVvar(name string) (interface{}, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = c.dec.DecodeInterface()
+		_i, _err = c.dec.ReadIntf()
 
 		return
 	}
@@ -1655,7 +1662,7 @@ func (c *Client) GetVvar(name string) (interface{}, error) {
 func (c *Client) GetWindows() ([]Window, error) {
 	var retVal []Window
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(0)
+		_err = c.enc.WriteArrayHeader(0)
 		if _err != nil {
 			return
 		}
@@ -1689,7 +1696,7 @@ func (c *Client) GetWindows() ([]Window, error) {
 func (c *Client) Input(keys string) (int, error) {
 	var retVal int
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -1704,7 +1711,7 @@ func (c *Client) Input(keys string) (int, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = c.dec.DecodeInt()
+		_i, _err = c.dec.ReadInt()
 
 		return
 	}
@@ -1729,7 +1736,7 @@ func (c *Client) Input(keys string) (int, error) {
 func (c *Client) ListRuntimePaths() ([]string, error) {
 	var retVal []string
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(0)
+		_err = c.enc.WriteArrayHeader(0)
 		if _err != nil {
 			return
 		}
@@ -1759,11 +1766,51 @@ func (c *Client) ListRuntimePaths() ([]string, error) {
 
 }
 
+// NameToColor waiting for documentation from Neovim
+func (c *Client) NameToColor(name string) (int, error) {
+	var retVal int
+	enc := func() (_err error) {
+		_err = c.enc.WriteArrayHeader(1)
+		if _err != nil {
+			return
+		}
+
+		_err = c.encodeString(name)
+
+		if _err != nil {
+			return
+		}
+
+		return
+	}
+	dec := func() (_i interface{}, _err error) {
+
+		_i, _err = c.dec.ReadInt()
+
+		return
+	}
+	respChan, err := c.makeCall(clientNameToColor, enc, dec)
+	if err != nil {
+		return retVal, c.panicOrReturn(errors.Annotate(err, "Could not make call to Client.NameToColor"))
+	}
+	resp := <-respChan
+	if resp == nil {
+		return retVal, c.panicOrReturn(errors.New("We got a nil response on respChan"))
+	}
+	if resp.err != nil {
+		return retVal, c.panicOrReturn(errors.Annotate(err, "We got a non-nil error in our response"))
+	}
+
+	retVal = resp.obj.(int)
+	return retVal, nil
+
+}
+
 // OutWrite waiting for documentation from Neovim
 func (c *Client) OutWrite(str string) error {
 
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -1778,7 +1825,7 @@ func (c *Client) OutWrite(str string) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = c.dec.DecodeBytes()
+		_err = c.dec.ReadNil()
 
 		return
 	}
@@ -1802,7 +1849,7 @@ func (c *Client) OutWrite(str string) error {
 func (c *Client) ReplaceTermcodes(str string, fromPart bool, doLt bool, special bool) (string, error) {
 	var retVal string
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(4)
+		_err = c.enc.WriteArrayHeader(4)
 		if _err != nil {
 			return
 		}
@@ -1813,19 +1860,19 @@ func (c *Client) ReplaceTermcodes(str string, fromPart bool, doLt bool, special 
 			return
 		}
 
-		_err = c.enc.EncodeBool(fromPart)
+		_err = c.enc.WriteBool(fromPart)
 
 		if _err != nil {
 			return
 		}
 
-		_err = c.enc.EncodeBool(doLt)
+		_err = c.enc.WriteBool(doLt)
 
 		if _err != nil {
 			return
 		}
 
-		_err = c.enc.EncodeBool(special)
+		_err = c.enc.WriteBool(special)
 
 		if _err != nil {
 			return
@@ -1860,7 +1907,7 @@ func (c *Client) ReplaceTermcodes(str string, fromPart bool, doLt bool, special 
 func (c *Client) ReportError(str string) error {
 
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -1875,7 +1922,7 @@ func (c *Client) ReportError(str string) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = c.dec.DecodeBytes()
+		_err = c.dec.ReadNil()
 
 		return
 	}
@@ -1899,7 +1946,7 @@ func (c *Client) ReportError(str string) error {
 func (c *Client) SetCurrentBuffer(buffer Buffer) error {
 
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -1914,7 +1961,7 @@ func (c *Client) SetCurrentBuffer(buffer Buffer) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = c.dec.DecodeBytes()
+		_err = c.dec.ReadNil()
 
 		return
 	}
@@ -1938,7 +1985,7 @@ func (c *Client) SetCurrentBuffer(buffer Buffer) error {
 func (c *Client) SetCurrentLine(line string) error {
 
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -1953,7 +2000,7 @@ func (c *Client) SetCurrentLine(line string) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = c.dec.DecodeBytes()
+		_err = c.dec.ReadNil()
 
 		return
 	}
@@ -1977,7 +2024,7 @@ func (c *Client) SetCurrentLine(line string) error {
 func (c *Client) SetCurrentTabpage(tabpage Tabpage) error {
 
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -1992,7 +2039,7 @@ func (c *Client) SetCurrentTabpage(tabpage Tabpage) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = c.dec.DecodeBytes()
+		_err = c.dec.ReadNil()
 
 		return
 	}
@@ -2016,7 +2063,7 @@ func (c *Client) SetCurrentTabpage(tabpage Tabpage) error {
 func (c *Client) SetCurrentWindow(window Window) error {
 
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -2031,7 +2078,7 @@ func (c *Client) SetCurrentWindow(window Window) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = c.dec.DecodeBytes()
+		_err = c.dec.ReadNil()
 
 		return
 	}
@@ -2055,7 +2102,7 @@ func (c *Client) SetCurrentWindow(window Window) error {
 func (c *Client) SetOption(name string, value interface{}) error {
 
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(2)
+		_err = c.enc.WriteArrayHeader(2)
 		if _err != nil {
 			return
 		}
@@ -2066,7 +2113,7 @@ func (c *Client) SetOption(name string, value interface{}) error {
 			return
 		}
 
-		_err = c.enc.Encode(value)
+		_err = c.enc.WriteIntf(value)
 
 		if _err != nil {
 			return
@@ -2076,7 +2123,7 @@ func (c *Client) SetOption(name string, value interface{}) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = c.dec.DecodeBytes()
+		_err = c.dec.ReadNil()
 
 		return
 	}
@@ -2100,7 +2147,7 @@ func (c *Client) SetOption(name string, value interface{}) error {
 func (c *Client) SetVar(name string, value interface{}) (interface{}, error) {
 	var retVal interface{}
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(2)
+		_err = c.enc.WriteArrayHeader(2)
 		if _err != nil {
 			return
 		}
@@ -2111,7 +2158,7 @@ func (c *Client) SetVar(name string, value interface{}) (interface{}, error) {
 			return
 		}
 
-		_err = c.enc.Encode(value)
+		_err = c.enc.WriteIntf(value)
 
 		if _err != nil {
 			return
@@ -2121,7 +2168,7 @@ func (c *Client) SetVar(name string, value interface{}) (interface{}, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = c.dec.DecodeInterface()
+		_i, _err = c.dec.ReadIntf()
 
 		return
 	}
@@ -2146,7 +2193,7 @@ func (c *Client) SetVar(name string, value interface{}) (interface{}, error) {
 func (c *Client) Strwidth(str string) (int, error) {
 	var retVal int
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -2161,7 +2208,7 @@ func (c *Client) Strwidth(str string) (int, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = c.dec.DecodeInt()
+		_i, _err = c.dec.ReadInt()
 
 		return
 	}
@@ -2186,7 +2233,7 @@ func (c *Client) Strwidth(str string) (int, error) {
 func (c *Client) Subscribe(event string) error {
 
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -2201,7 +2248,7 @@ func (c *Client) Subscribe(event string) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = c.dec.DecodeBytes()
+		_err = c.dec.ReadNil()
 
 		return
 	}
@@ -2225,7 +2272,7 @@ func (c *Client) Subscribe(event string) error {
 func (c *Client) Unsubscribe(event string) error {
 
 	enc := func() (_err error) {
-		_err = c.enc.EncodeSliceLen(1)
+		_err = c.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -2240,7 +2287,7 @@ func (c *Client) Unsubscribe(event string) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = c.dec.DecodeBytes()
+		_err = c.dec.ReadNil()
 
 		return
 	}
@@ -2264,7 +2311,7 @@ func (c *Client) Unsubscribe(event string) error {
 func (w *Window) GetBuffer() (Buffer, error) {
 	var retVal Buffer
 	enc := func() (_err error) {
-		_err = w.client.enc.EncodeSliceLen(1)
+		_err = w.client.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -2303,7 +2350,7 @@ func (w *Window) GetBuffer() (Buffer, error) {
 func (w *Window) GetCursor() ([]int, error) {
 	var retVal []int
 	enc := func() (_err error) {
-		_err = w.client.enc.EncodeSliceLen(1)
+		_err = w.client.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -2342,7 +2389,7 @@ func (w *Window) GetCursor() ([]int, error) {
 func (w *Window) GetHeight() (int, error) {
 	var retVal int
 	enc := func() (_err error) {
-		_err = w.client.enc.EncodeSliceLen(1)
+		_err = w.client.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -2356,7 +2403,7 @@ func (w *Window) GetHeight() (int, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = w.client.dec.DecodeInt()
+		_i, _err = w.client.dec.ReadInt()
 
 		return
 	}
@@ -2381,7 +2428,7 @@ func (w *Window) GetHeight() (int, error) {
 func (w *Window) GetOption(name string) (interface{}, error) {
 	var retVal interface{}
 	enc := func() (_err error) {
-		_err = w.client.enc.EncodeSliceLen(2)
+		_err = w.client.enc.WriteArrayHeader(2)
 		if _err != nil {
 			return
 		}
@@ -2401,7 +2448,7 @@ func (w *Window) GetOption(name string) (interface{}, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = w.client.dec.DecodeInterface()
+		_i, _err = w.client.dec.ReadIntf()
 
 		return
 	}
@@ -2426,7 +2473,7 @@ func (w *Window) GetOption(name string) (interface{}, error) {
 func (w *Window) GetPosition() ([]int, error) {
 	var retVal []int
 	enc := func() (_err error) {
-		_err = w.client.enc.EncodeSliceLen(1)
+		_err = w.client.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -2465,7 +2512,7 @@ func (w *Window) GetPosition() ([]int, error) {
 func (w *Window) GetTabpage() (Tabpage, error) {
 	var retVal Tabpage
 	enc := func() (_err error) {
-		_err = w.client.enc.EncodeSliceLen(1)
+		_err = w.client.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -2504,7 +2551,7 @@ func (w *Window) GetTabpage() (Tabpage, error) {
 func (w *Window) GetVar(name string) (interface{}, error) {
 	var retVal interface{}
 	enc := func() (_err error) {
-		_err = w.client.enc.EncodeSliceLen(2)
+		_err = w.client.enc.WriteArrayHeader(2)
 		if _err != nil {
 			return
 		}
@@ -2524,7 +2571,7 @@ func (w *Window) GetVar(name string) (interface{}, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = w.client.dec.DecodeInterface()
+		_i, _err = w.client.dec.ReadIntf()
 
 		return
 	}
@@ -2549,7 +2596,7 @@ func (w *Window) GetVar(name string) (interface{}, error) {
 func (w *Window) GetWidth() (int, error) {
 	var retVal int
 	enc := func() (_err error) {
-		_err = w.client.enc.EncodeSliceLen(1)
+		_err = w.client.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -2563,7 +2610,7 @@ func (w *Window) GetWidth() (int, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = w.client.dec.DecodeInt()
+		_i, _err = w.client.dec.ReadInt()
 
 		return
 	}
@@ -2588,7 +2635,7 @@ func (w *Window) GetWidth() (int, error) {
 func (w *Window) IsValid() (bool, error) {
 	var retVal bool
 	enc := func() (_err error) {
-		_err = w.client.enc.EncodeSliceLen(1)
+		_err = w.client.enc.WriteArrayHeader(1)
 		if _err != nil {
 			return
 		}
@@ -2602,7 +2649,7 @@ func (w *Window) IsValid() (bool, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = w.client.dec.DecodeBool()
+		_i, _err = w.client.dec.ReadBool()
 
 		return
 	}
@@ -2627,7 +2674,7 @@ func (w *Window) IsValid() (bool, error) {
 func (w *Window) SetCursor(pos []int) error {
 
 	enc := func() (_err error) {
-		_err = w.client.enc.EncodeSliceLen(2)
+		_err = w.client.enc.WriteArrayHeader(2)
 		if _err != nil {
 			return
 		}
@@ -2647,7 +2694,7 @@ func (w *Window) SetCursor(pos []int) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = w.client.dec.DecodeBytes()
+		_err = w.client.dec.ReadNil()
 
 		return
 	}
@@ -2671,7 +2718,7 @@ func (w *Window) SetCursor(pos []int) error {
 func (w *Window) SetHeight(height int) error {
 
 	enc := func() (_err error) {
-		_err = w.client.enc.EncodeSliceLen(2)
+		_err = w.client.enc.WriteArrayHeader(2)
 		if _err != nil {
 			return
 		}
@@ -2681,7 +2728,7 @@ func (w *Window) SetHeight(height int) error {
 			return
 		}
 
-		_err = w.client.enc.EncodeInt(height)
+		_err = w.client.enc.WriteInt(height)
 
 		if _err != nil {
 			return
@@ -2691,7 +2738,7 @@ func (w *Window) SetHeight(height int) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = w.client.dec.DecodeBytes()
+		_err = w.client.dec.ReadNil()
 
 		return
 	}
@@ -2715,7 +2762,7 @@ func (w *Window) SetHeight(height int) error {
 func (w *Window) SetOption(name string, value interface{}) error {
 
 	enc := func() (_err error) {
-		_err = w.client.enc.EncodeSliceLen(3)
+		_err = w.client.enc.WriteArrayHeader(3)
 		if _err != nil {
 			return
 		}
@@ -2731,7 +2778,7 @@ func (w *Window) SetOption(name string, value interface{}) error {
 			return
 		}
 
-		_err = w.client.enc.Encode(value)
+		_err = w.client.enc.WriteIntf(value)
 
 		if _err != nil {
 			return
@@ -2741,7 +2788,7 @@ func (w *Window) SetOption(name string, value interface{}) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = w.client.dec.DecodeBytes()
+		_err = w.client.dec.ReadNil()
 
 		return
 	}
@@ -2765,7 +2812,7 @@ func (w *Window) SetOption(name string, value interface{}) error {
 func (w *Window) SetVar(name string, value interface{}) (interface{}, error) {
 	var retVal interface{}
 	enc := func() (_err error) {
-		_err = w.client.enc.EncodeSliceLen(3)
+		_err = w.client.enc.WriteArrayHeader(3)
 		if _err != nil {
 			return
 		}
@@ -2781,7 +2828,7 @@ func (w *Window) SetVar(name string, value interface{}) (interface{}, error) {
 			return
 		}
 
-		_err = w.client.enc.Encode(value)
+		_err = w.client.enc.WriteIntf(value)
 
 		if _err != nil {
 			return
@@ -2791,7 +2838,7 @@ func (w *Window) SetVar(name string, value interface{}) (interface{}, error) {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_i, _err = w.client.dec.DecodeInterface()
+		_i, _err = w.client.dec.ReadIntf()
 
 		return
 	}
@@ -2816,7 +2863,7 @@ func (w *Window) SetVar(name string, value interface{}) (interface{}, error) {
 func (w *Window) SetWidth(width int) error {
 
 	enc := func() (_err error) {
-		_err = w.client.enc.EncodeSliceLen(2)
+		_err = w.client.enc.WriteArrayHeader(2)
 		if _err != nil {
 			return
 		}
@@ -2826,7 +2873,7 @@ func (w *Window) SetWidth(width int) error {
 			return
 		}
 
-		_err = w.client.enc.EncodeInt(width)
+		_err = w.client.enc.WriteInt(width)
 
 		if _err != nil {
 			return
@@ -2836,7 +2883,7 @@ func (w *Window) SetWidth(width int) error {
 	}
 	dec := func() (_i interface{}, _err error) {
 
-		_, _err = w.client.dec.DecodeBytes()
+		_err = w.client.dec.ReadNil()
 
 		return
 	}
@@ -2857,42 +2904,17 @@ func (w *Window) SetWidth(width int) error {
 }
 
 func (c *Client) decodeBuffer() (retVal Buffer, retErr error) {
-	b, err := c.dec.R.ReadByte()
+	retVal.client = c
+	err := c.dec.ReadExtension(&retVal)
 	if err != nil {
-		return retVal, errors.Annotatef(err, "Could not decode control byte")
+		return retVal, errors.Annotatef(err, "Could not decode extension Buffer")
 	}
 
-	// TODO: use appropriate constant
-	if b != 0xd4 {
-		return retVal, errors.Errorf("Expected code d4; got %v\n", b)
-	}
-
-	t, err := c.dec.DecodeUint8()
-	if err != nil {
-		return retVal, errors.Annotatef(err, "Could not decode type")
-	}
-
-	if t != typeBuffer {
-		return retVal, errors.Annotatef(err, "Expected typeBuffer; got: %v\n", t)
-	}
-
-	bid, err := c.dec.DecodeUint8()
-	if err != nil {
-		return retVal, errors.Annotatef(err, "Could not decode Buffer ID")
-	}
-	return Buffer{ID: uint32(bid), client: c}, retErr
+	return
 }
 
 func (c *Client) encodeBuffer(b Buffer) error {
-	err := c.enc.W.WriteByte(0xd4)
-	if err != nil {
-		return errors.Annotatef(err, "Could not encode Buffer ext type")
-	}
-	err = c.enc.EncodeUint8(typeBuffer)
-	if err != nil {
-		return errors.Annotatef(err, "Could not encode Buffer type")
-	}
-	err = c.enc.EncodeUint8(uint8(b.ID))
+	err := c.enc.WriteExtension(&b)
 	if err != nil {
 		return errors.Annotatef(err, "Could not encode Buffer")
 	}
@@ -2900,42 +2922,17 @@ func (c *Client) encodeBuffer(b Buffer) error {
 }
 
 func (c *Client) decodeWindow() (retVal Window, retErr error) {
-	b, err := c.dec.R.ReadByte()
+	retVal.client = c
+	err := c.dec.ReadExtension(&retVal)
 	if err != nil {
-		return retVal, errors.Annotatef(err, "Could not decode control byte")
+		return retVal, errors.Annotatef(err, "Could not decode extension Window")
 	}
 
-	// TODO: use appropriate constant
-	if b != 0xd4 {
-		return retVal, errors.Errorf("Expected code d4; got %v\n", b)
-	}
-
-	t, err := c.dec.DecodeUint8()
-	if err != nil {
-		return retVal, errors.Annotatef(err, "Could not decode type")
-	}
-
-	if t != typeWindow {
-		return retVal, errors.Annotatef(err, "Expected typeWindow; got: %v\n", t)
-	}
-
-	bid, err := c.dec.DecodeUint8()
-	if err != nil {
-		return retVal, errors.Annotatef(err, "Could not decode Window ID")
-	}
-	return Window{ID: uint32(bid), client: c}, retErr
+	return
 }
 
 func (c *Client) encodeWindow(b Window) error {
-	err := c.enc.W.WriteByte(0xd4)
-	if err != nil {
-		return errors.Annotatef(err, "Could not encode Window ext type")
-	}
-	err = c.enc.EncodeUint8(typeWindow)
-	if err != nil {
-		return errors.Annotatef(err, "Could not encode Window type")
-	}
-	err = c.enc.EncodeUint8(uint8(b.ID))
+	err := c.enc.WriteExtension(&b)
 	if err != nil {
 		return errors.Annotatef(err, "Could not encode Window")
 	}
@@ -2943,42 +2940,17 @@ func (c *Client) encodeWindow(b Window) error {
 }
 
 func (c *Client) decodeTabpage() (retVal Tabpage, retErr error) {
-	b, err := c.dec.R.ReadByte()
+	retVal.client = c
+	err := c.dec.ReadExtension(&retVal)
 	if err != nil {
-		return retVal, errors.Annotatef(err, "Could not decode control byte")
+		return retVal, errors.Annotatef(err, "Could not decode extension Tabpage")
 	}
 
-	// TODO: use appropriate constant
-	if b != 0xd4 {
-		return retVal, errors.Errorf("Expected code d4; got %v\n", b)
-	}
-
-	t, err := c.dec.DecodeUint8()
-	if err != nil {
-		return retVal, errors.Annotatef(err, "Could not decode type")
-	}
-
-	if t != typeTabpage {
-		return retVal, errors.Annotatef(err, "Expected typeTabpage; got: %v\n", t)
-	}
-
-	bid, err := c.dec.DecodeUint8()
-	if err != nil {
-		return retVal, errors.Annotatef(err, "Could not decode Tabpage ID")
-	}
-	return Tabpage{ID: uint32(bid), client: c}, retErr
+	return
 }
 
 func (c *Client) encodeTabpage(b Tabpage) error {
-	err := c.enc.W.WriteByte(0xd4)
-	if err != nil {
-		return errors.Annotatef(err, "Could not encode Tabpage ext type")
-	}
-	err = c.enc.EncodeUint8(typeTabpage)
-	if err != nil {
-		return errors.Annotatef(err, "Could not encode Tabpage type")
-	}
-	err = c.enc.EncodeUint8(uint8(b.ID))
+	err := c.enc.WriteExtension(&b)
 	if err != nil {
 		return errors.Annotatef(err, "Could not encode Tabpage")
 	}
@@ -2988,7 +2960,7 @@ func (c *Client) encodeTabpage(b Tabpage) error {
 // helper functions for types
 
 func (c *Client) encodeBufferSlice(s []Buffer) error {
-	err := c.enc.EncodeSliceLen(len(s))
+	err := c.enc.WriteArrayHeader(uint32(len(s)))
 	if err != nil {
 		return errors.Annotate(err, "Could not encode slice length")
 	}
@@ -3006,14 +2978,15 @@ func (c *Client) encodeBufferSlice(s []Buffer) error {
 }
 
 func (c *Client) decodeBufferSlice() ([]Buffer, error) {
-	l, err := c.dec.DecodeSliceLen()
+	l, err := c.dec.ReadArrayHeader()
 	if err != nil {
 		return nil, errors.Annotate(err, "Could not decode slice length")
 	}
 
 	res := make([]Buffer, l)
 
-	for i := 0; i < l; i++ {
+	var i uint32
+	for i = 0; i < l; i++ {
 
 		b, err := c.decodeBuffer()
 
@@ -3027,7 +3000,7 @@ func (c *Client) decodeBufferSlice() ([]Buffer, error) {
 }
 
 func (c *Client) encodeTabpageSlice(s []Tabpage) error {
-	err := c.enc.EncodeSliceLen(len(s))
+	err := c.enc.WriteArrayHeader(uint32(len(s)))
 	if err != nil {
 		return errors.Annotate(err, "Could not encode slice length")
 	}
@@ -3045,14 +3018,15 @@ func (c *Client) encodeTabpageSlice(s []Tabpage) error {
 }
 
 func (c *Client) decodeTabpageSlice() ([]Tabpage, error) {
-	l, err := c.dec.DecodeSliceLen()
+	l, err := c.dec.ReadArrayHeader()
 	if err != nil {
 		return nil, errors.Annotate(err, "Could not decode slice length")
 	}
 
 	res := make([]Tabpage, l)
 
-	for i := 0; i < l; i++ {
+	var i uint32
+	for i = 0; i < l; i++ {
 
 		b, err := c.decodeTabpage()
 
@@ -3066,7 +3040,7 @@ func (c *Client) decodeTabpageSlice() ([]Tabpage, error) {
 }
 
 func (c *Client) encodeWindowSlice(s []Window) error {
-	err := c.enc.EncodeSliceLen(len(s))
+	err := c.enc.WriteArrayHeader(uint32(len(s)))
 	if err != nil {
 		return errors.Annotate(err, "Could not encode slice length")
 	}
@@ -3084,14 +3058,15 @@ func (c *Client) encodeWindowSlice(s []Window) error {
 }
 
 func (c *Client) decodeWindowSlice() ([]Window, error) {
-	l, err := c.dec.DecodeSliceLen()
+	l, err := c.dec.ReadArrayHeader()
 	if err != nil {
 		return nil, errors.Annotate(err, "Could not decode slice length")
 	}
 
 	res := make([]Window, l)
 
-	for i := 0; i < l; i++ {
+	var i uint32
+	for i = 0; i < l; i++ {
 
 		b, err := c.decodeWindow()
 
@@ -3105,14 +3080,14 @@ func (c *Client) decodeWindowSlice() ([]Window, error) {
 }
 
 func (c *Client) encodeIntSlice(s []int) error {
-	err := c.enc.EncodeSliceLen(len(s))
+	err := c.enc.WriteArrayHeader(uint32(len(s)))
 	if err != nil {
 		return errors.Annotate(err, "Could not encode slice length")
 	}
 
 	for i := 0; i < len(s); i++ {
 
-		err := c.enc.EncodeInt(s[i])
+		err := c.enc.WriteInt(s[i])
 
 		if err != nil {
 			return errors.Annotatef(err, "Could not encode int at index %v", i)
@@ -3123,16 +3098,17 @@ func (c *Client) encodeIntSlice(s []int) error {
 }
 
 func (c *Client) decodeIntSlice() ([]int, error) {
-	l, err := c.dec.DecodeSliceLen()
+	l, err := c.dec.ReadArrayHeader()
 	if err != nil {
 		return nil, errors.Annotate(err, "Could not decode slice length")
 	}
 
 	res := make([]int, l)
 
-	for i := 0; i < l; i++ {
+	var i uint32
+	for i = 0; i < l; i++ {
 
-		b, err := c.dec.DecodeInt()
+		b, err := c.dec.ReadInt()
 
 		if err != nil {
 			return nil, errors.Annotatef(err, "Could not decode int at index %v", i)
@@ -3144,7 +3120,7 @@ func (c *Client) decodeIntSlice() ([]int, error) {
 }
 
 func (c *Client) encodeStringSlice(s []string) error {
-	err := c.enc.EncodeSliceLen(len(s))
+	err := c.enc.WriteArrayHeader(uint32(len(s)))
 	if err != nil {
 		return errors.Annotate(err, "Could not encode slice length")
 	}
@@ -3162,14 +3138,15 @@ func (c *Client) encodeStringSlice(s []string) error {
 }
 
 func (c *Client) decodeStringSlice() ([]string, error) {
-	l, err := c.dec.DecodeSliceLen()
+	l, err := c.dec.ReadArrayHeader()
 	if err != nil {
 		return nil, errors.Annotate(err, "Could not decode slice length")
 	}
 
 	res := make([]string, l)
 
-	for i := 0; i < l; i++ {
+	var i uint32
+	for i = 0; i < l; i++ {
 
 		b, err := c.decodeString()
 

--- a/gen_client_api_test.go
+++ b/gen_client_api_test.go
@@ -83,6 +83,8 @@ type neovimTester interface {
 	BenchmarkClientInput(*check.C)
 	TestClientListRuntimePaths(*check.C)
 	BenchmarkClientListRuntimePaths(*check.C)
+	TestClientNameToColor(*check.C)
+	BenchmarkClientNameToColor(*check.C)
 	TestClientOutWrite(*check.C)
 	BenchmarkClientOutWrite(*check.C)
 	TestClientReplaceTermcodes(*check.C)


### PR DESCRIPTION
A more definite line in the sand

* Now dependent on Go `>= 1.4`
* Switch to using the brilliant [`msgp`](https://github.com/tinylib/msgp)
* Regen the Neovim API (currently lacking support for two functions, see TODO linked below)
* Establish the basis for defining plugins (`example/example.go`) with both sync and async functions
* Establish the basis for the code generated wrapper around a plugin (`example/gen_example.go`)
* Use `msgp` to generate MSGPACK wrappers around plugin wrappers (!) (`example/gen_example_gen.go`)
* A (temporary) working plugin manager that for now takes a single plugin package as a parameter and installs the compiled plugin
* Steps on how to use this `Example` plugin (see `example/README.md`)

A list of remaining TODOs is being created/maintained [here](https://github.com/myitcv/neovim/wiki/TODO)
